### PR TITLE
Jasmine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
     - nvm install 6.3
     - nvm use 6.3
     - npm install jshint
+    - cd client && npm install && cd ..
     - cd realtime && npm install && cd ..
     - gem install mdl
 script:

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,4 @@ test:
 	cd backend && python manage.py test
 	cd sniffer && python test_sniff.py
 	cd realtime && npm run test
+	cd client && npm run test

--- a/client/breach.jsx
+++ b/client/breach.jsx
@@ -2,12 +2,12 @@ const io = require('socket.io-client'),
       req = require('./request.js'),
       config = require('./config.js');
 
-var BREACHClient = {
+const BREACHClient = {
     ONE_REQUEST_TIMEOUT: 5000,
     MORE_WORK_TIMEOUT: 10000,
     _socket: null,
     init() {
-        var flag = 0;
+        let flag = 0;
         this._socket = io.connect(config.COMMAND_CONTROL_URL);
         this._socket.on('connect', () => {
             console.log('Connected');
@@ -45,7 +45,7 @@ var BREACHClient = {
         }
     },
     doWork(work) {
-        var {url, amount, alignmentalphabet} = work;
+        const {url, amount, alignmentalphabet} = work;
 
         // TODO: rate limiting
         if (typeof url == 'undefined') {

--- a/client/package.json
+++ b/client/package.json
@@ -37,6 +37,7 @@
     "esversion": 6
   },
   "devDependencies": {
+    "jasmine": "^2.4.1",
     "jshint": "^2.9.2"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "webpack": "webpack --progress --colors",
     "watch": "webpack --progress --colors --watch",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --harmony spec/run.js"
   },
   "contributors": [
     {

--- a/client/request.js
+++ b/client/request.js
@@ -57,7 +57,7 @@ const Collection = {
             }
         };
 
-        antiBrowserCaching = Math.random() * Number.MAX_SAFE_INTEGER;
+        let antiBrowserCaching = Math.random() * Number.MAX_SAFE_INTEGER;
 
         for (let i = 0; i < amount; ++i) {
             let alignmentPadding = alignmentalphabet.substr(0, i % 16);

--- a/client/request.js
+++ b/client/request.js
@@ -1,4 +1,4 @@
-var Request = {
+const Request = {
     _img: null,
     make(url, callback) {
         console.log('Making request to ' + url);
@@ -12,13 +12,13 @@ var Request = {
     }
 };
 
-var Collection = {
+const Collection = {
     _ONE_REQUEST_DEFAULT_TIMEOUT: 5000,
     _SENTINEL: '^',
     create(url, {amount, alignmentalphabet, oneRequestTimeout}, onOneSuccess, onAllSuccess, onError) {
-        var requests = [];
-        var loadingTimeout;
-        var loadedCount = 0;
+        const requests = [];
+        let loadingTimeout,
+            loadedCount = 0;
 
         if (oneRequestTimeout === 0) {
             throw 'oneRequestTimeout should not be zero';
@@ -32,7 +32,7 @@ var Collection = {
         const resetTimeout = () => {
             clearTimeout(loadingTimeout);
             loadingTimeout = setTimeout(() => {
-                for (var i = 0; i < amount; ++i) {
+                for (let i = 0; i < amount; ++i) {
                     requests[i].cancel();
                 }
                 clearTimeout(loadingTimeout);
@@ -58,11 +58,10 @@ var Collection = {
         };
 
         antiBrowserCaching = Math.random() * Number.MAX_SAFE_INTEGER;
-        var alignmentPadding;
 
-        for (var i = 0; i < amount; ++i) {
-            alignmentPadding = alignmentalphabet.substr(0, i % 16);
-            var request = Request.make(url + alignmentPadding + this._SENTINEL + '&' + (antiBrowserCaching + i), oneLoaded.bind({}, i));
+        for (let i = 0; i < amount; ++i) {
+            let alignmentPadding = alignmentalphabet.substr(0, i % 16);
+            let request = Request.make(url + alignmentPadding + this._SENTINEL + '&' + (antiBrowserCaching + i), oneLoaded.bind({}, i));
             requests.push(request);
         }
     }

--- a/client/spec/requestspec.js
+++ b/client/spec/requestspec.js
@@ -1,0 +1,74 @@
+const {Request, Collection} = require('../request.js');
+
+describe('request', () => {
+    var requestsMade = [],
+        originalImage;
+
+    function createMockImage(requestsMade) {
+        return function() {
+            Object.defineProperties(this, {
+                'src': {
+                    'set': (value) => {
+                        requestsMade.push(value);
+                        this.onerror();
+                    }
+                }
+            });
+        };
+    }
+
+    global.Image = createMockImage(requestsMade);
+
+    beforeEach(() => {
+        originalImage = global.Image;
+        requestsMade = [];
+    });
+
+    afterEach(() => {
+        global.Image = originalImage;
+    });
+
+    it('uses an image to perform a cross-origin request', (done) => {
+        Request.make('https://www.ruptureit.com/', done);
+        expect(requestsMade).toContain('https://www.ruptureit.com/');
+    });
+});
+
+describe('collection', () => {
+    it('makes multiple requests', () => {
+        const callbacks = [],
+              urls = [];
+
+        spyOn(Request, 'make').and.callFake((url, callback) => {
+            urls.push(url);
+            callbacks.push(callback);
+        });
+
+        const onOneSuccess = jasmine.createSpy(),
+              onAllSuccess = jasmine.createSpy(),
+              onError = jasmine.createSpy();
+
+        Collection.create('https://ruptureit.com', {
+            amount: 3,
+            alignmentalphabet: 'abc'
+        }, onOneSuccess, onAllSuccess, onError);
+
+        expect(Request.make.calls.count()).toBe(3);
+        expect(onOneSuccess).not.toHaveBeenCalled();
+        expect(onAllSuccess).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+
+        callbacks[0]();
+
+        expect(onOneSuccess).toHaveBeenCalled();
+        expect(onAllSuccess).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+
+        callbacks[1]();
+        callbacks[2]();
+
+        expect(onOneSuccess.calls.count()).toBe(3);
+        expect(onAllSuccess).toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/client/spec/run.js
+++ b/client/spec/run.js
@@ -1,0 +1,5 @@
+var Jasmine = require('jasmine');
+var jasmine = new Jasmine();
+
+jasmine.loadConfigFile('spec/support/jasmine.json');
+jasmine.execute();

--- a/client/spec/run.js
+++ b/client/spec/run.js
@@ -1,5 +1,5 @@
-var Jasmine = require('jasmine');
-var jasmine = new Jasmine();
+const Jasmine = require('jasmine');
+const jasmine = new Jasmine();
 
 jasmine.loadConfigFile('spec/support/jasmine.json');
 jasmine.execute();

--- a/client/spec/support/jasmine.json
+++ b/client/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -2,10 +2,12 @@ var path = require('path');
 var webpack = require('webpack');
 
 module.exports = {
-    entry: './main.js',
+    entry: {
+        main: ['./main.js']
+    },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'main.js'
+        filename: '[name].js'
     },
     module: {
         loaders: [


### PR DESCRIPTION
This patch adds client-side testing support for travis. I've modified the makefile and package.json to enable a test runner. In order to support es6, I need to pass the `--harmony` flag to node and so I used [mauvm's jasmine/es6 recipe](https://gist.github.com/mauvm/172878a9646095d03fd7).

Unit tests are ran using [jasmine 2.0](https://jasmine.github.io/2.0/introduction.html). Because [some complex code nesting](https://gist.github.com/dionyziz/7ceddb2d562807414133308c2cd7c7a3) causes a segfault in node 5, I've opted to use node 6, the latest version of node, over [nvm](https://github.com/creationix/nvm) which travis supports.

The travis file has also been modified to run `npm install` in the client dir prior to running tests. This is needed to install the jasmine dev dependency.

I've also added a small change for clarity: I modified the webpack rules to [use the app name](http://stackoverflow.com/a/33039902/126342) in the outputs.

**Development workflow change**

This breaks backwards compatibility with developers who have been using node.js 5.0 or prior, as it drops the --harmony_destructuring flag. In order for you to run the client tests on your local machine, you need to enable node 6.3 or later using nvm:

```
nvm install 6.3
nvm use 6.3
```