### PR TITLE
Faster babel

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -14,7 +14,8 @@ module.exports = {
                 exclude: /node_modules/,
                 loader: 'babel-loader',
                 query: {
-                    presets: ['es2015']
+                    presets: ['es2015'],
+                    cacheDirectory: true
                 }
             }
         ]

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
         loaders: [
             {
                 test: /\.jsx?$/,
+                exclude: /node_modules/,
                 loader: 'babel-loader',
                 query: {
                     presets: ['es2015']


### PR DESCRIPTION
This patch optimizes the client build from 4.15 seconds down to 1.72 seconds. Most of the optimization (1.92 seconds) is due to excluding node_modules sources from transpilation.

An additional 0.46 seconds is gained by caching compilation results, but this is only achieved after the first transpilation has successfully completed.

**Benchmarks**

**Before optimization:**

```
(rupture)dionyziz@vm ~/workspace/rupture/client % time npm run webpack

> rupture-client@1.0.0 webpack /home/dionyziz/workspace/rupture/client
> webpack --progress --colors

Hash: d7dbda48f674580e453a  
Version: webpack 1.13.1
Time: 3838ms
      Asset    Size  Chunks             Chunk Names
    main.js  205 kB       0  [emitted]  main
main.js.map  333 kB       0  [emitted]  main
    + 54 hidden modules
npm run webpack  4,15s user 0,23s system 95% cpu 4,595 total
```

**After excluding node_modules:**

```
(rupture)dionyziz@vm ~/workspace/rupture/client % time npm run webpack

> rupture-client@1.0.0 webpack /home/dionyziz/workspace/rupture/client
> webpack --progress --colors

Hash: f14eddabaf17a99ddedd  
Version: webpack 1.13.1
Time: 1745ms
      Asset    Size  Chunks             Chunk Names
    main.js  201 kB       0  [emitted]  main
main.js.map  246 kB       0  [emitted]  main
    + 54 hidden modules
npm run webpack  2,22s user 0,14s system 95% cpu 2,475 total
```

**With caching:**

```
(rupture)dionyziz@vm ~/workspace/rupture/client % time npm run webpack

> rupture-client@1.0.0 webpack /home/dionyziz/workspace/rupture/client
> webpack --progress --colors

Hash: f14eddabaf17a99ddedd  
Version: webpack 1.13.1
Time: 1340ms
      Asset    Size  Chunks             Chunk Names
    main.js  201 kB       0  [emitted]  main
main.js.map  246 kB       0  [emitted]  main
    + 54 hidden modules
npm run webpack  1,76s user 0,13s system 93% cpu 2,019 total
```