### PR TITLE
Realtime test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 sudo: true
 install:
     - pip install pep8
-    - npm install jshint
     - cd backend && pip install -r requirements.txt && cd ..
     - cd sniffer && pip install -r requirements.txt && cd ..
+    - nvm install 6.3
+    - nvm use 6.3
+    - npm install jshint
     - cd realtime && npm install && cd ..
 script:
     - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ install:
     - npm install jshint
     - cd backend && pip install -r requirements.txt && cd ..
     - cd sniffer && pip install -r requirements.txt && cd ..
+    - cd realtime && npm install && cd ..
 script:
     - make all

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,4 @@ syntax:
 test:
 	cd backend && python manage.py test
 	cd sniffer && python test_sniff.py
+	cd realtime && npm run test

--- a/etc/spec/ARCHITECTURE.md
+++ b/etc/spec/ARCHITECTURE.md
@@ -373,8 +373,9 @@ makes requests for work. This API is explained below.
 The backend implements various API endpoints for communication with the
 real-time server.
 
-### /getwork
-Requests work to be performed on behalf of a client.
+### /get_work/<victim>
+
+HTTP GET endpoint. Requests work to be performed on behalf of a client.
 
 Arguments:
  - victim: The id of the victim.
@@ -389,7 +390,9 @@ In case no work is available for the client, it returns an HTTP `404` response.
 Work can be unavailable in case a different client is already collecting data
 for the particular victim, and we do not wish to interfere with it.
 
-### /workcompleted
+### /work_completed/<victim>
+
+HTTP POST endpoint.
 
 Indicates on behalf of the client that some work was successfully or
 unsuccessfully completed.

--- a/etc/spec/ARCHITECTURE.md
+++ b/etc/spec/ARCHITECTURE.md
@@ -318,7 +318,7 @@ The client / real-time protocol is implemented using
 ### client-hello / server-hello
 
 When the client initially connects to the real-time server, it sends the message
-**client-hello** passing its *victim-id* to the real-time server.  The server
+**client-hello** passing its *victim_id* to the real-time server.  The server
 responds with a **server-hello** message. After these handshake messages are
 exchanged, the client and server can exchange futher messages.
 

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -74,7 +74,7 @@ socket.on('connection', (client) => {
                     client.emit('do-work', JSON.parse(responseData));
                     winston.info('Got (get-work) response from backend: ' + responseData);
                 }
-                catch(e) {
+                catch (e) {
                     winston.error('Got invalid (get-work) response from backend');
                     doNoWork();
                 }
@@ -116,7 +116,7 @@ socket.on('connection', (client) => {
                         createNewWork();
                     }
                 }
-                catch(e) {
+                catch (e) {
                     winston.error('Got invalid (work-completed) response from backend');
                     doNoWork();
                 }

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -16,11 +16,11 @@ var victims = {};
 const BACKEND_HOST = 'localhost',
       BACKEND_PORT = '8000';
 
-socket.on('connection', function(client) {
+socket.on('connection', (client) => {
     winston.info('New connection from client ' + client.id);
 
     var victimId;
-    client.on('client-hello', function({victim_id}) {
+    client.on('client-hello', ({victim_id}) => {
         if (!victims.victim_id) {
             victimId = victim_id;
             client.emit('server-hello');
@@ -30,23 +30,23 @@ socket.on('connection', function(client) {
         }
     });
 
-    var doNoWork = function() {
+    var doNoWork = () => {
         client.emit('do-work', {});
     };
 
-    var createNewWork = function() {
+    var createNewWork = () => {
         var getWorkOptions = {
             host: BACKEND_HOST,
             port: BACKEND_PORT,
             path: '/breach/get_work/' + victimId
         };
 
-        var getWorkRequest = http.request(getWorkOptions, function(response) {
+        var getWorkRequest = http.request(getWorkOptions, (response) => {
             var responseData = '';
-            response.on('data', function(chunk) {
+            response.on('data', (chunk) => {
                 responseData += chunk;
             });
-            response.on('end', function() {
+            response.on('end', () => {
                 try {
                     client.emit('do-work', JSON.parse(responseData));
                     winston.info('Got (get-work) response from backend: ' + responseData);
@@ -57,14 +57,14 @@ socket.on('connection', function(client) {
                 }
             });
         });
-        getWorkRequest.on('error', function(err) {
+        getWorkRequest.on('error', (err) => {
             winston.error('Caught getWorkRequest error: ' + err);
             doNoWork();
         });
         getWorkRequest.end();
     };
 
-    var reportWorkCompleted = function(work) {
+    var reportWorkCompleted = (work) => {
         var requestBodyString = JSON.stringify(work);
 
         var workCompletedOptions = {
@@ -78,12 +78,12 @@ socket.on('connection', function(client) {
             method: 'POST',
         };
 
-        var workCompletedRequest = http.request(workCompletedOptions, function(response) {
+        var workCompletedRequest = http.request(workCompletedOptions, (response) => {
             var responseData = '';
-            response.on('data', function(chunk) {
+            response.on('data', (chunk) => {
                 responseData += chunk;
             });
-            response.on('end', function() {
+            response.on('end', () => {
                 try {
                     var victory = JSON.parse(responseData).victory;
 
@@ -99,7 +99,7 @@ socket.on('connection', function(client) {
                 }
             });
         });
-        workCompletedRequest.on('error', function(err) {
+        workCompletedRequest.on('error', (err) => {
             winston.error('Caught workCompletedRequest error: ' + err);
             doNoWork();
         });
@@ -107,20 +107,20 @@ socket.on('connection', function(client) {
         workCompletedRequest.end();
     };
 
-    client.on('get-work', function() {
+    client.on('get-work', () => {
         winston.info('get-work from client ' + client.id);
         victims.victimId = client.id;
         createNewWork();
     });
 
-    client.on('work-completed', function({work, success, host}) {
+    client.on('work-completed', ({work, success, host}) => {
         winston.info('Client indicates work completed: ', work, success, host);
 
         var requestBody = work;
         requestBody.success = success;
         reportWorkCompleted(requestBody);
     });
-    client.on('disconnect', function() {
+    client.on('disconnect', () => {
         winston.info('Client ' + client.id + ' disconnected');
 
         for (var i in victims) {

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -12,6 +12,7 @@ const io = require('socket.io'),
       winston = require('winston'),
       http = require('http');
 
+winston.level = 'debug';
 winston.remove(winston.transports.Console);
 winston.add(winston.transports.Console, {'timestamp': true});
 

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -1,3 +1,13 @@
+const program = require('commander');
+
+program
+    .version('0.0.1')
+    .option('-p, --port <port>', 'specify the websocket port to listen to [3031]', 3031)
+    .option('-H, --backend-host <hostname>', 'specify the hostname of the HTTP backend service to connect to [localhost]', 'localhost')
+    .option('-P, --backend-port <port>', 'specify the port of the HTTP backend service to connect to [8000]', 8000)
+    .parse(process.argv);
+
+
 const io = require('socket.io'),
       winston = require('winston'),
       http = require('http');
@@ -5,7 +15,7 @@ const io = require('socket.io'),
 winston.remove(winston.transports.Console);
 winston.add(winston.transports.Console, {'timestamp': true});
 
-const PORT = 3031;
+const PORT = program.port;
 
 winston.info('Rupture real-time service starting');
 winston.info('Listening on port ' + PORT);
@@ -13,8 +23,10 @@ winston.info('Listening on port ' + PORT);
 var socket = io.listen(PORT);
 var victims = {};
 
-const BACKEND_HOST = 'localhost',
-      BACKEND_PORT = '8000';
+const BACKEND_HOST = program.backendHost;
+      BACKEND_PORT = program.backendPort;
+
+winston.info('Backed by backend service running at ' + BACKEND_HOST + ':' + BACKEND_PORT);
 
 socket.on('connection', (client) => {
     winston.info('New connection from client ' + client.id);

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -21,8 +21,8 @@ const PORT = program.port;
 winston.info('Rupture real-time service starting');
 winston.info('Listening on port ' + PORT);
 
-var socket = io.listen(PORT);
-var victims = {};
+const socket = io.listen(PORT);
+const victims = {};
 
 const BACKEND_HOST = program.backendHost;
       BACKEND_PORT = program.backendPort;
@@ -32,9 +32,9 @@ winston.info('Backed by backend service running at ' + BACKEND_HOST + ':' + BACK
 socket.on('connection', (client) => {
     winston.info('New connection from client ' + client.id);
 
-    var victimId;
+    let victimId;
     client.on('client-hello', (data) => {
-        var victim_id;
+        let victim_id;
 
         try {
             ({victim_id} = data);
@@ -53,12 +53,12 @@ socket.on('connection', (client) => {
         }
     });
 
-    var doNoWork = () => {
+    const doNoWork = () => {
         client.emit('do-work', {});
     };
 
-    var createNewWork = () => {
-        var getWorkOptions = {
+    const createNewWork = () => {
+        const getWorkOptions = {
             host: BACKEND_HOST,
             port: BACKEND_PORT,
             path: '/breach/get_work/' + victimId
@@ -66,8 +66,8 @@ socket.on('connection', (client) => {
 
         winston.debug('Forwarding get_work request to backend URL ' + getWorkOptions.path);
 
-        var getWorkRequest = http.request(getWorkOptions, (response) => {
-            var responseData = '';
+        const getWorkRequest = http.request(getWorkOptions, (response) => {
+            let responseData = '';
             response.on('data', (chunk) => {
                 responseData += chunk;
             });
@@ -89,10 +89,10 @@ socket.on('connection', (client) => {
         getWorkRequest.end();
     };
 
-    var reportWorkCompleted = (work) => {
-        var requestBodyString = JSON.stringify(work);
+    const reportWorkCompleted = (work) => {
+        const requestBodyString = JSON.stringify(work);
 
-        var workCompletedOptions = {
+        const workCompletedOptions = {
             host: BACKEND_HOST,
             port: BACKEND_PORT,
             headers: {
@@ -103,14 +103,14 @@ socket.on('connection', (client) => {
             method: 'POST',
         };
 
-        var workCompletedRequest = http.request(workCompletedOptions, (response) => {
-            var responseData = '';
+        const workCompletedRequest = http.request(workCompletedOptions, (response) => {
+            let responseData = '';
             response.on('data', (chunk) => {
                 responseData += chunk;
             });
             response.on('end', () => {
                 try {
-                    var victory = JSON.parse(responseData).victory;
+                    const victory = JSON.parse(responseData).victory;
 
                     winston.info('Got (work-completed) response from backend: ' + responseData);
 
@@ -139,7 +139,7 @@ socket.on('connection', (client) => {
     });
 
     client.on('work-completed', (data) => {
-        var work, success, host;
+        let work, success, host;
 
         try {
             ({work, success, host} = data);
@@ -151,20 +151,20 @@ socket.on('connection', (client) => {
 
         winston.info('Client indicates work completed: ', work, success, host);
 
-        var requestBody = work;
+        const requestBody = work;
         requestBody.success = success;
         reportWorkCompleted(requestBody);
     });
     client.on('disconnect', () => {
         winston.info('Client ' + client.id + ' disconnected');
 
-        for (var i in victims) {
+        for (let i in victims) {
             if (victims.i == client.id) {
                 victims.i = null;
             }
         }
 
-        var requestBody = {
+        const requestBody = {
             success: false
         };
         reportWorkCompleted(requestBody);

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -64,6 +64,8 @@ socket.on('connection', (client) => {
             path: '/breach/get_work/' + victimId
         };
 
+        winston.debug('Forwarding get_work request to backend URL ' + getWorkOptions.path);
+
         var getWorkRequest = http.request(getWorkOptions, (response) => {
             var responseData = '';
             response.on('data', (chunk) => {

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -33,7 +33,17 @@ socket.on('connection', (client) => {
     winston.info('New connection from client ' + client.id);
 
     var victimId;
-    client.on('client-hello', ({victim_id}) => {
+    client.on('client-hello', (data) => {
+        var victim_id;
+
+        try {
+            ({victim_id} = data);
+        }
+        catch (e) {
+            winston.error('Got invalid client-hello message from client');
+            return;
+        }
+
         if (!victims.victim_id) {
             victimId = victim_id;
             client.emit('server-hello');
@@ -126,7 +136,17 @@ socket.on('connection', (client) => {
         createNewWork();
     });
 
-    client.on('work-completed', ({work, success, host}) => {
+    client.on('work-completed', (data) => {
+        var work, success, host;
+
+        try {
+            ({work, success, host} = data);
+        }
+        catch (e) {
+            winston.error('Got invalid work-completed from client');
+            return;
+        }
+
         winston.info('Client indicates work completed: ', work, success, host);
 
         var requestBody = work;

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "commander": "^2.9.0",
     "socket.io": "^1.4.5",
     "winston": "^2.2.0"
   },

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -15,8 +15,11 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
     "jasmine": "^2.4.1",
-    "jshint": "^2.9.2"
+    "jshint": "^2.9.2",
+    "socket.io-client": "^1.4.8"
   },
   "jshintConfig": {
     "esversion": 6

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node --harmony --harmony_destructuring index.js"
+    "start": "node --harmony index.js"
   },
   "author": "",
   "license": "MIT",

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -15,6 +15,7 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
+    "jasmine": "^2.4.1",
     "jshint": "^2.9.2"
   },
   "jshintConfig": {

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -4,7 +4,7 @@
   "description": "Rupture real-time service",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --harmony spec/run.js",
     "start": "node --harmony index.js"
   },
   "author": "",

--- a/realtime/spec/realtimespec.js
+++ b/realtime/spec/realtimespec.js
@@ -1,0 +1,124 @@
+const spawn = require('child_process').spawn;
+const client = require('socket.io-client');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+function runServer() {
+    server = spawn(
+        'node',
+        [
+            '--harmony',
+            'index.js',
+            '--port', '9909',
+            '--backend-host', 'localhost',
+            '--backend-port', '9908'
+        ]
+    );
+
+    server.stdout.on('data', (data) => {
+        console.log(data.toString());
+    });
+    server.stderr.on('data', (data) => {
+        console.log(data.toString());
+    });
+    server.on('exit', () => {
+        console.log('Server terminated');
+    });
+
+    return server;
+}
+
+function connect() {
+    const socket = client('http://localhost:9909');
+
+    socket.on('error', () => {});
+
+    return socket;
+}
+
+describe('real-time service', () => {
+    let server,
+        socket;
+
+    beforeEach(() => {
+        server = runServer();
+        socket = connect();
+    });
+
+    it('listens for websocket connections', (done) => {
+        socket.on('connect', done);
+    });
+
+    it('exchanges hello messages', function(done) {
+        socket.on('connect', () => {
+            socket.emit('client-hello', {victim_id: 5});
+            socket.on('server-hello', done);
+        });
+    });
+
+    describe('backend communication', () => {
+        let fakeServer;
+
+        function fakeBackend(listenCallback, method, url, getCallback) {
+            const app = express();
+            app.use(bodyParser.json());
+            app[method](url, getCallback);
+            fakeServer = app.listen(9908, listenCallback);
+        }
+
+        beforeEach((done) => {
+            socket.on('connect', () => {
+                socket.emit('client-hello', {victim_id: 5});
+                done();
+            });
+        });
+
+        it('requests work from the backend', function(done) {
+            fakeBackend(
+                () => {
+                    socket.emit('get-work');
+                },
+                'get',
+                '/breach/get_work/5',
+                done
+            );
+        });
+
+        it('reports work-completed to the backend', function(done) {
+            fakeBackend(
+                () => {
+                    socket.emit('work-completed', {work: {}, success: true});
+                },
+                'post',
+                '/breach/work_completed/5',
+                (request, response) => {
+                    expect(request.body.success).toBe(true);
+                    done();
+                }
+            );
+        });
+
+        it('reports failed work-completed after a client disconnects', function(done) {
+            fakeBackend(
+                () => {
+                    socket.close();
+                },
+                'post',
+                '/breach/work_completed/5',
+                (request, response) => {
+                    expect(request.body.success).toBe(false);
+                    done();
+                }
+            );
+        });
+
+        afterEach(() => {
+            fakeServer.close();
+        });
+    });
+
+    afterEach(() => {
+        server.kill();
+        socket.close();
+    });
+});

--- a/realtime/spec/run.js
+++ b/realtime/spec/run.js
@@ -1,0 +1,5 @@
+const Jasmine = require('jasmine');
+const jasmine = new Jasmine();
+
+jasmine.loadConfigFile('spec/support/jasmine.json');
+jasmine.execute();

--- a/realtime/spec/support/jasmine.json
+++ b/realtime/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
This patch adds end-to-end tests for the realtime service.

I modified the realtime service to support command-line parameters using [commander.js](https://github.com/tj/commander.js).

[Jasmine](https://jasmine.github.io/2.0/introduction.html) is used to write the end-to-end tests for realtime, similar to how we #176 uses Jasmine for client-side tests. The [spec runner](https://gist.github.com/mauvm/172878a9646095d03fd7) is the same. Similarly, [nvm](https://github.com/creationix/nvm) is required to set up node 6.0 and run the tests without the `--harmony_destructuring` parameter.

The end-to-end tests for the realtime service are performed by creating a websocket client using [socket.io-client](https://github.com/socketio/socket.io-client) and performing probing requests on the server. The backend service is mocked using [express](https://expressjs.com/).

**Development workflow change**

This introduces the same development workflow changes as #176.