### PR TITLE
Coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ env/
 .DS_Store
 tags
 *.aux
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ install:
     - gem install mdl
 script:
     - make all
+after_success:
+    - cd backend && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
 script:
     - make all
 after_success:
-    - cd backend && coveralls
+    - coveralls

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,4 @@ test:
 	cd sniffer && python test_sniff.py
 	cd realtime && npm run test
 	cd client && npm run test
+	cd realtime && npm run test

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,4 @@ test:
 	cd sniffer && nosetests --with-coverage --cover-package=app,sniffer
 	cd realtime && npm run test
 	cd client && npm run test
+	coverage combine backend/.coverage sniffer/.coverage

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ syntax:
 	mdl --rules ~MD036 etc
 test:
 	cd backend && python manage.py test
-	cd sniffer && python test_sniff.py
+	cd sniffer && nosetests --with-coverage --cover-package=app,sniffer
 	cd realtime && npm run test
 	cd client && npm run test
-	cd realtime && npm run test

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_nose'
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -162,3 +163,12 @@ LOGGING = {
         }
     }
 }
+
+# Testing settings
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-package=breach'
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,9 @@ Django==1.9.2
 PyYAML==3.11
 argh==0.26.1
 argparse==1.2.1
+coverage==4.2
+coveralls==1.1
+django-nose==1.4.4
 funcsigs==0.4
 mock==1.3.0
 pathtools==0.1.2

--- a/sniffer/requirements.txt
+++ b/sniffer/requirements.txt
@@ -2,3 +2,4 @@ Flask==0.10.1
 scapy==2.3.2
 tl.testing==0.5
 mock==1.3.0
+nose==1.3.7


### PR DESCRIPTION
**Depends #176.**

This patch adds django and sniffer coverage metrics. You can use [coveralls](https://coveralls.io/builds/7239952/source?filename=breach%2Fstrategy.py) to check what was covered.

To measure coverage, I used the [nose](http://nose.readthedocs.io/en/latest/) test runner. For the backend, I integrated nose using [django-nose](https://github.com/django-nose/django-nose). Coverage is measured using [coverage](http://coverage.readthedocs.io/). Coverage reports for different source portions are [combined](http://coverage.readthedocs.io/en/coverage-4.0.3/cmd.html) into a common view.