### PR TITLE
Update Django version

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -42,7 +42,6 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE_CLASSES = [
-    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.9.2
+Django==1.7.7
 PyYAML==3.11
 coverage==4.2
 coveralls==1.1


### PR DESCRIPTION
Django version 1.9 is available only on latest Debian release. In order to allow Rupture installation on Debian 8 we need to downgrade to Django 1.7.7, which means we need to remove the security middleware, that is unnecessary anyway in our usecase.